### PR TITLE
Text too big to fit on long inputs

### DIFF
--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -32,7 +32,7 @@ atom-panel.modal, .overlay {
     max-height: 32px + @component-padding;
     height: 32px + @component-padding;
     line-height: 32px;
-    font-size: 24px;
+    font-size: 16px;
     font-weight: 300 !important;
 
     &.is-focused:hover,


### PR DESCRIPTION
I've noticed that when renaming a file, if the path is a bit long, the text doesn't fit and it's break into two lines and the end part of the file is missing
