### PR TITLE
Add scrollbar styles

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -104,3 +104,45 @@ kbd {
   font-size: 90%;
   border-radius: @component-border-radius/2;
 }
+
+.scrollbars-visible-always {
+  /deep/ ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  /deep/ ::-webkit-scrollbar-track,
+  /deep/ ::-webkit-scrollbar-corner {
+    background: @scrollbar-track-color;
+  }
+
+  /deep/ ::-webkit-scrollbar-thumb {
+    border-radius: 1px;
+    background: @scrollbar-color;
+    border: 1px solid @scrollbar-border;
+    background-clip: content-box;
+    border-right: 0px;
+  }
+
+  /deep/ ::-webkit-scrollbar-thumb:vertical:active {
+    border-radius: 0;
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+
+  /deep/ ::-webkit-scrollbar-thumb:horizontal:active {
+    border-radius: 0;
+    border-top-width: 0;
+    border-bottom-width: 0;
+  }
+
+  atom-text-editor, .settings-view {
+    /deep/ ::-webkit-scrollbar-track,
+    /deep/ ::-webkit-scrollbar-corner {
+      background: @scrollbar-track-color;
+    }
+    /deep/ ::-webkit-scrollbar-thumb {
+      border-right: 1px solid @scrollbar-border;
+    }
+  }
+}

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -13,6 +13,7 @@ atom-panel {
   }
   &.bottom > *:not(:empty) {
     border-top: 1px solid @tool-panel-border-color;
+    z-index: 3;
   }
 }
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -126,6 +126,10 @@
 @markdown-preview-background-color: @syntax-background-color;
 @markdown-preview-border-color: mix(@syntax-text-color, @syntax-background-color, 20%);
 
+@scrollbar-border: @theme-background-color-lighter;
+@scrollbar-color: @theme-background-color-light;
+@scrollbar-track-color: @theme-background-color;
+
 // Site colors  ----------------------------------------------------------------
 @ui-site-color-1: @theme-green;
 @ui-site-color-2: @theme-blue;


### PR DESCRIPTION
Apologies for the git issues - you probably got way too many notifications about this....

Love this theme and wanted to add some scrollbar styles - they're visible on Mac if you set "Show scroll bars" to "Always" in "General Settings". The color of the scroll bars match the background color of the theme you're using.

Before:
![screen shot 2015-07-26 at 2 40 10 pm](https://cloud.githubusercontent.com/assets/7041728/8895331/59464912-33a4-11e5-8ba4-bacf22399f9d.png)

After:
![screen shot 2015-07-31 at 12 41 16 am](https://cloud.githubusercontent.com/assets/7041728/9000881/efde6e24-371c-11e5-83d6-954d563db083.png)

Great work on this theme! :+1: 
