### PR TITLE
Shrink modals when window gets narrow

### DIFF
--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -12,6 +12,14 @@ atom-panel.modal,
   padding: @component-padding @component-padding*2;
   width: 680px;
   margin-left: -340px;
+  
+  @media (max-width: 680px) {
+    & {
+      width: 100%;
+      left: 0;
+      margin-left: 0;
+    }
+  }
 
   label,
   p {


### PR DESCRIPTION
When looking into https://github.com/atom/atom/pull/10782, I noticed this theme uses a custom width for modals.

This PR overrides the core styles to make modals flexible in width when the window gets narrow.
