### PR TITLE
Fix selected background width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nucleus-dark-ui",
   "theme": "ui",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "An adaptable UI with your favorite syntax theme at its core!",
   "keywords": [
     "dark",

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -16,6 +16,7 @@
 
   li.selected:before {
     background: @background-color-selected;
+    width: 100vh;
   }
 
   li.selected .character-match {


### PR DESCRIPTION
This is just fix for selected item in tree view. When you have really big tree of files then background highlighting is too small for when you scroll horizontally in tree view.

Example:
http://prntscr.com/a8jr6n
