### PR TITLE
No padding for build panel

### DIFF
--- a/styles/packages.less
+++ b/styles/packages.less
@@ -21,6 +21,7 @@ autocomplete-suggestion-list.select-list.popover-list .suggestion-description-co
 
 // build -----------------------------------------------------------------------
 .build {
+  padding: 0;
   border-left: 0;
   animation: none !important;
 


### PR DESCRIPTION
Like any UI change this is debatable. I really don't like the padding on the build panel. I've had this in my `styles.less` for a while, and thought I'd make a PR out of it. I'm sure more feel the same as I do.

Thanks for a great theme. My first choice, btw!
