### PR TITLE
Increase padding for fold icon

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -58,7 +58,7 @@ atom-text-editor::shadow,
       opacity: 1.0;
       color: @gutter-text-color;
       border-left: 2px solid transparent;
-      padding-left: @component-padding !important;
+      // padding-left: @component-padding !important;
       padding-right: 0;
       width: inherit;
 
@@ -108,7 +108,6 @@ atom-text-editor::shadow,
       .icon-right {
         opacity: 1.0;
         color: @gutter-text-color;
-        padding: 0 .75em;
       }
 
       .icon-right:hover {

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -108,6 +108,7 @@ atom-text-editor::shadow,
       .icon-right {
         opacity: 1.0;
         color: @gutter-text-color;
+        padding: 0 .75em;
       }
 
       .icon-right:hover {


### PR DESCRIPTION
Hello.

Currently, the fold icon appear covered by the editor on my Macbook:
(notice the little white dot on line 103 and 108.)

![screen shot 2016-05-05 at 12 25 18 am](https://cloud.githubusercontent.com/assets/1299411/15022987/7e55e24c-1258-11e6-9aa9-f0e0896a116c.png)

What I've done is simply tweak the padding value for `.icon-right` class so that the fold icon is visible.Here is the screenshot after I added the padding:

![screen shot 2016-05-05 at 12 25 57 am](https://cloud.githubusercontent.com/assets/1299411/15023030/c278e47e-1258-11e6-8812-6edd542207bf.png)

If there are better ways in doing this, please let me know; I'd be happy to adjust. I am also wondering if I am the only one experiencing this issue.
