### PR TITLE
Fix padding on config folder button

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -48,6 +48,11 @@
 
     button.close:before {
       color: @text-color-error;
+      .button-area {
+        .btn {
+            padding: 0;
+        }
+    }
     }
   }
 


### PR DESCRIPTION
Remove padding for config folder button to keep text from hitting button border
