### PR TITLE
remove deprecated selectors resolves #96

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,6 +1,4 @@
-atom-text-editor,
-atom-text-editor::shadow,
-:host {
+atom-text-editor {
   .wrap-guide {
     background: @base-border-color;
   }

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -36,8 +36,7 @@
   }
 }
 
-atom-text-editor.mini,
-atom-text-editor.mini::shadow {
+atom-text-editor.mini  {
   .transition();
   background: @base-border-color;
   border-radius: @component-border-radius;
@@ -59,9 +58,7 @@ atom-text-editor.mini::shadow {
 }
 
 atom-text-editor.mini.is-focused,
-atom-text-editor.mini.is-focused::shadow,
-atom-text-editor.mini:hover,
-atom-text-editor.mini:hover::shadow{
+atom-text-editor.mini:hover {
   background: @input-background-color;
   .text,
   .regexp {

--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -62,8 +62,7 @@ atom-panel.modal {
     }
   }
 
-  atom-text-editor.mini,
-  atom-text-editor.mini::shadow {
+  atom-text-editor.mini {
     max-height: none;
     background-color: transparent;
     border: 0;


### PR DESCRIPTION
remove deprecated selectors clean up `:host` & `::shadow` selectors per Atom deprecation warnings.