### PR TITLE
Fix modal content not showing

### DIFF
--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -27,7 +27,7 @@ atom-panel.modal {
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 0;
+    z-index: -1; // Makes sure this doesn't cover anything inside the modal
     background-color: @overlay-background-color;
     border-radius: @component-border-radius;
   }


### PR DESCRIPTION
When working on a new modal dialog, @jasonrudolph [noticed](https://github.com/atom/teletype/pull/350#issuecomment-375458816) that the text isn't visible when this theme is used. Turns out that the [pseudo element](https://github.com/ignism/nucleus-dark-ui/blob/d6b6b50a0e0bdba50e7c5c6d78ee7e13a0a49e8b/styles/overlays.less#L22-L34) used for the shadow covers some content of the modal. Moving the shadow under the content with `z-index: -1;` seems to work.

Before | After
--- | ---
![screen shot 2018-03-23 at 1 04 39 pm](https://user-images.githubusercontent.com/378023/37811029-d0febe1e-2e9a-11e8-92bd-649d1f69a4c4.png) | ![screen shot 2018-03-23 at 1 04 53 pm](https://user-images.githubusercontent.com/378023/37811030-d12d068e-2e9a-11e8-959b-c3fbad94d8a5.png)



### Alternative approach

An alternative might be to use 

```less
atom-panel.modal > * {
  position: relative;
}
```

and move the content above the shadow.